### PR TITLE
Fix JSON format in medicine endpoints

### DIFF
--- a/src/infrastructure/rest/controllers/medicine/Medicines.go
+++ b/src/infrastructure/rest/controllers/medicine/Medicines.go
@@ -127,7 +127,8 @@ func (c *Controller) GetMedicinesByID(ctx *gin.Context) {
 		return
 	}
 	c.Logger.Info("Successfully retrieved medicine by ID", zap.Int("id", medicineID))
-	ctx.JSON(http.StatusOK, dMed)
+	resp := domainToResponseMapper(dMed)
+	ctx.JSON(http.StatusOK, resp)
 }
 
 func (c *Controller) UpdateMedicine(ctx *gin.Context) {
@@ -159,7 +160,8 @@ func (c *Controller) UpdateMedicine(ctx *gin.Context) {
 		return
 	}
 	c.Logger.Info("Medicine updated successfully", zap.Int("id", medicineID))
-	ctx.JSON(http.StatusOK, updated)
+	resp := domainToResponseMapper(updated)
+	ctx.JSON(http.StatusOK, resp)
 }
 
 func (c *Controller) DeleteMedicine(ctx *gin.Context) {


### PR DESCRIPTION
## Summary
- return standardized JSON objects from the medicine controller

## Testing
- `go test ./...` *(fails: proxy.golang.org access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6865a27325e08330941862450c4956a6