### PR TITLE
Fix authentication error codes

### DIFF
--- a/src/application/usecases/auth/auth.go
+++ b/src/application/usecases/auth/auth.go
@@ -48,13 +48,13 @@ func (s *AuthUseCase) Login(email, password string) (*domainUser.User, *AuthToke
 	}
 	if user.ID == 0 {
 		s.Logger.Warn("Login failed: user not found", zap.String("email", email))
-		return nil, nil, domainErrors.NewAppError(errors.New("email or password does not match"), domainErrors.NotAuthorized)
+		return nil, nil, domainErrors.NewAppError(errors.New("email or password does not match"), domainErrors.NotAuthenticated)
 	}
 
 	isAuthenticated := checkPasswordHash(password, user.HashPassword)
 	if !isAuthenticated {
 		s.Logger.Warn("Login failed: invalid password", zap.String("email", email))
-		return nil, nil, domainErrors.NewAppError(errors.New("email or password does not match"), domainErrors.NotAuthorized)
+		return nil, nil, domainErrors.NewAppError(errors.New("email or password does not match"), domainErrors.NotAuthenticated)
 	}
 
 	accessTokenClaims, err := s.JWTService.GenerateJWTToken(user.ID, "access")

--- a/src/infrastructure/security/jwt_service.go
+++ b/src/infrastructure/security/jwt_service.go
@@ -133,12 +133,12 @@ func (s *JWTService) GetClaimsAndVerifyToken(tokenString string, tokenType strin
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, domainErrors.NewAppError(err, domainErrors.NotAuthenticated)
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok || !token.Valid {
-		return nil, errors.New("invalid claims type or token not valid")
+		return nil, domainErrors.NewAppError(errors.New("invalid claims type or token not valid"), domainErrors.NotAuthenticated)
 	}
 
 	if claims["type"] != tokenType {
@@ -147,11 +147,11 @@ func (s *JWTService) GetClaimsAndVerifyToken(tokenString string, tokenType strin
 
 	expVal, ok := claims["exp"]
 	if !ok || expVal == nil {
-		return nil, errors.New("token missing expiration (exp) claim")
+		return nil, domainErrors.NewAppError(errors.New("token missing expiration (exp) claim"), domainErrors.NotAuthenticated)
 	}
 	timeExpire, ok := expVal.(float64)
 	if !ok {
-		return nil, errors.New("token expiration (exp) claim is not a float64")
+		return nil, domainErrors.NewAppError(errors.New("token expiration (exp) claim is not a float64"), domainErrors.NotAuthenticated)
 	}
 	if time.Now().Unix() > int64(timeExpire) {
 		return nil, domainErrors.NewAppError(errors.New("token expired"), domainErrors.NotAuthenticated)
@@ -159,14 +159,14 @@ func (s *JWTService) GetClaimsAndVerifyToken(tokenString string, tokenType strin
 
 	idVal, ok := claims["id"]
 	if !ok || idVal == nil {
-		return nil, errors.New("token missing id claim")
+		return nil, domainErrors.NewAppError(errors.New("token missing id claim"), domainErrors.NotAuthenticated)
 	}
 	// Accept float64 or int64 for id
 	switch idVal.(type) {
 	case float64, int64, int:
 		// ok
 	default:
-		return nil, errors.New("token id claim is not a number")
+		return nil, domainErrors.NewAppError(errors.New("token id claim is not a number"), domainErrors.NotAuthenticated)
 	}
 
 	return claims, nil


### PR DESCRIPTION
## Summary
- handle invalid credentials as `NotAuthenticated`
- wrap JWT parsing errors in `NotAuthenticated`

## Testing
- `bash scripts/run-integration-test.bash -v -f auth.feature` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6865a66580c483308bed43ba76a31b97