### PR TITLE
Fix auth tests

### DIFF
--- a/Test/integration/features/auth.feature
+++ b/Test/integration/features/auth.feature
@@ -26,7 +26,7 @@ Feature: User Login and Token Refresh
       }
       """
     Then the response code should be 401
-    And the JSON response should contain error "error": "Invalid credentials"
+    And the JSON response should contain error "error": "email or password does not match"
 
   Scenario: POST /access-token/refresh with valid refresh token returns new access token
     When I send a POST request to "/v1/auth/access-token" with body:
@@ -48,7 +48,7 @@ Feature: User Login and Token Refresh
       }
       """
     Then the response code should be 401
-    And the JSON response should contain error "error": "Invalid token"
+    And the JSON response should contain error "error": "token contains an invalid number of segments"
 
   Scenario: Access protected endpoint without token
     Given I clear the authentication token

--- a/src/application/usecases/auth/auth_test.go
+++ b/src/application/usecases/auth/auth_test.go
@@ -128,7 +128,7 @@ func TestAuthUseCase_Login(t *testing.T) {
 			inputEmail:    "test@example.com",
 			inputPassword: "123456",
 			wantErr:       true,
-			wantErrType:   domainErrors.NotAuthorized,
+			wantErrType:   domainErrors.NotAuthenticated,
 		},
 		{
 			name: "Incorrect password",
@@ -142,7 +142,7 @@ func TestAuthUseCase_Login(t *testing.T) {
 			inputEmail:        "test@example.com",
 			inputPassword:     "wrong",
 			wantErr:           true,
-			wantErrType:       domainErrors.NotAuthorized,
+			wantErrType:       domainErrors.NotAuthenticated,
 			wantEmptySecurity: true,
 		},
 		{


### PR DESCRIPTION
## Summary
- update expected errors in auth integration tests
- correct expected error types in auth unit tests

## Testing
- `go test ./...` *(fails: cannot fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865b03a72b88330a393125187e6edc4