### PR TITLE
Fix integration test script path in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ go test ./...
 ./coverage.sh
 
 # Run integration tests
-./Test/integration/run-integration-test.bash
+./scripts/run-integration-test.bash
 
 # Lint code
 golangci-lint run ./...

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -682,7 +682,7 @@ https://www.postman.com/kts-mexico/workspace/boilerplategomicroservice
 
 ```bash
 # Run integration tests
-./Test/integration/run-integration-test.bash
+./scripts/run-integration-test.bash
 
 # Run unit tests
 go test ./...

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@ docker-compose up --build -d
 
 # Run tests
 ./coverage.sh
-./Test/integration/run-integration-test.bash
+./scripts/run-integration-test.bash
 ```
 
 ### 2. **API Testing**


### PR DESCRIPTION
## Summary
- reference the correct scripts directory for integration tests in README files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865b8d68e6883309838daa3c9787d9e